### PR TITLE
Fix missing folders pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-kanban",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "scripts": {
     "test": "jest",
     "dist": "webpack --joplin-plugin-config buildMain && webpack --joplin-plugin-config buildExtraScripts && webpack --joplin-plugin-config createArchive",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "id": "com.github.joplin.kanban",
   "app_min_version": "1.7",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "name": "Kanban",
   "description": "Flexible kanban board plugin for all your tasks",
   "author": "Balint Magyar",

--- a/src/noteData.ts
+++ b/src/noteData.ts
@@ -207,7 +207,7 @@ export async function createNotebook(notebookPath: string): Promise<string> {
 export async function resolveNotebookPath(
   notebookPath: string
 ): Promise<string | null> {
-  const { items: foldersData } = await joplin.data.get(["folders"]);
+  const foldersData = await getAllNotebooks()
   const parts = notebookPath.split("/");
 
   let parentId = "";
@@ -230,7 +230,7 @@ export async function resolveNotebookPath(
 export async function findAllChildrenNotebook(
   parentId: string
 ): Promise<string[]> {
-  const { items: foldersData } = await joplin.data.get(["folders"]);
+  const foldersData = await getAllNotebooks()
 
   let children: string[] = [];
   const recurse = (id: string) => {


### PR DESCRIPTION
We forgot to paginate through all the pages when querying folders, this causes a bug when the user has more than 100 folders (See #6 )

I also bumped the version so you can release it right away.