### PR TITLE
Speed up loading time and show a loading text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-kanban",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "scripts": {
     "test": "jest",
     "dist": "webpack --joplin-plugin-config buildMain && webpack --joplin-plugin-config buildExtraScripts && webpack --joplin-plugin-config createArchive",

--- a/src/gui/index.tsx
+++ b/src/gui/index.tsx
@@ -101,7 +101,7 @@ function App() {
       )}
     </Container>
   ) : (
-    <div></div>
+    <h1>Loading...</h1>
   );
 
   return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,11 +247,11 @@ joplin.plugins.register({
     log("\nKANBAN PLUGIN STARTED\n");
 
     // Have to call this on start otherwise layout from prevoius session is lost
-    await showBoard();
-    hideBoard();
+    showBoard().then(hideBoard);
 
     joplin.workspace.onNoteSelectionChange(
       async ({ value }: { value: [string?] }) => {
+        log(`Note selection changed`);
         const newNoteId = value?.[0] as string;
         if (newNoteChangedCb && (await getNoteById(newNoteId))) newNoteChangedCb = undefined;
         if (newNoteId) handleNewlyOpenedNote(newNoteId);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "id": "com.github.joplin.kanban",
   "app_min_version": "1.7",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "name": "Kanban",
   "description": "Flexible kanban board plugin for all your tasks",
   "author": "Balint Magyar",

--- a/src/noteData.ts
+++ b/src/noteData.ts
@@ -55,6 +55,7 @@ async function search(query: string): Promise<NoteData[]> {
     has_more: boolean;
   };
 
+  let allNotes: any[] = [];
   const result: NoteData[] = [];
   let page = 1;
   while (true) {
@@ -62,6 +63,11 @@ async function search(query: string): Promise<NoteData[]> {
       query === "" ? ["notes"] : ["search"],
       { query, page, fields }
     );
+    allNotes = allNotes.concat(notes)
+
+    if (!hasMore) break;
+    else page++;
+  }
 
     for (const {
       id,
@@ -72,7 +78,7 @@ async function search(query: string): Promise<NoteData[]> {
       todo_due,
       order,
       created_time,
-    } of notes) {
+    } of allNotes) {
       const tags = (await joplin.data.get(["notes", id, "tags"])).items.map(
         ({ title }: { title: string }) => title
       );
@@ -88,10 +94,6 @@ async function search(query: string): Promise<NoteData[]> {
         createdTime: created_time,
       });
     }
-
-    if (!hasMore) break;
-    else page++;
-  }
 
   return result;
 }

--- a/src/noteData.ts
+++ b/src/noteData.ts
@@ -207,7 +207,7 @@ export async function createNotebook(notebookPath: string): Promise<string> {
 export async function resolveNotebookPath(
   notebookPath: string
 ): Promise<string | null> {
-  const { items: foldersData } = await joplin.data.get(["folders"]);
+  const foldersData = await getAllNotebooks()
   const parts = notebookPath.split("/");
 
   let parentId = "";
@@ -230,7 +230,7 @@ export async function resolveNotebookPath(
 export async function findAllChildrenNotebook(
   parentId: string
 ): Promise<string[]> {
-  const { items: foldersData } = await joplin.data.get(["folders"]);
+  const foldersData = await getAllNotebooks()
 
   let children: string[] = [];
   const recurse = (id: string) => {


### PR DESCRIPTION
This PR is based on #9. 
The main speedup is to make all the queries for notes, before querying the tags, otherwise, each note query needs to wait for the tags query. Also I use `Promise.all` to fire all tags queries simultaneously so it's faster then making all the queries sequentially. This reduced the loading time for a big folder from ~8 sec to ~4 sec.

I added a text "Loading..." when the GUI is waiting for the "backend" to feed it data. So the user feels it's loading faster.