### PR TITLE
Localized date format depending on plattform

### DIFF
--- a/src/gui/Card.tsx
+++ b/src/gui/Card.tsx
@@ -26,7 +26,7 @@ export default React.forwardRef<HTMLDivElement, { note: NoteData }>(
     ]);
     if (due > 0) {
       const dueDate = new Date(due);
-      const dateStr = `${dueDate.getMonth() + 1}.${dueDate.getDate()}`;
+      const dateStr = dueDate.toLocaleDateString(undefined, { month: 'numeric', day: 'numeric' });
       const daysLeft = (due - Date.now()) / (1000 * 60 * 60 * 24);
       const color = daysLeft < 3 ? "red" : undefined;
       extras.push([<IoCalendarOutline size="1rem" />, dateStr, color]);


### PR DESCRIPTION
Please consider using some sort of localized date display, instead of a fixed one, which is very unusual in my country...

even better would be something like:
```js
    if (due > 0) {
      const dueDate = new Date(due);
      const dueDateFormat = await joplin.settings.globalValue("dateFormat");
      const dateStr = moment(dueDate).format(dueDateFormat);
      const daysLeft = moment().diff(moment(dueDate), 'days');
      const color = daysLeft < 3 ? "red" : undefined;
      extras.push([<IoCalendarOutline size="1rem" />, dateStr, color]);
    }
```

using the date format defined in joplin settings.... if you'd using moment.js it would even make the days calculations easier