### PR TITLE
Improved Markdown view: note links and optional list view (resolves #17)

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -30,6 +30,9 @@ export interface Config {
     name: string;
     backlog?: boolean;
   }[];
+  display: {
+    markdown: string;
+  };
 }
 
 interface Column {
@@ -87,6 +90,22 @@ export function getMdTable(boardState: BoardState): string {
   const timestamp = `_Last updated at ${new Date().toLocaleString()} by Kanban plugin_`;
 
   return header + headerSep + body + timestamp;
+}
+
+export function getMdList(boardState: BoardState): string {
+  if (!boardState.columns) return "";
+
+  const numCols = boardState.columns.length;
+  const cols: string[] = [];
+  for (let i = 0; i < numCols; i++) {
+    cols[i] = ("## " + boardState.columns[i].name + "\n" +
+      boardState.columns[i].notes.map((note) => "- " + getMdLink(note)).join("\n"));
+  }
+
+  const body = cols.join("\n\n")
+  const timestamp = `\n\n_Last updated at ${new Date().toLocaleString()} by Kanban plugin_`;
+
+  return body + timestamp;
 }
 
 export function getMdLink(note: NoteData): string {

--- a/src/board.ts
+++ b/src/board.ts
@@ -80,13 +80,19 @@ export function getMdTable(boardState: BoardState): string {
   const rows: string[][] = [];
   const numRows = Math.max(...boardState.columns.map((c) => c.notes.length));
   for (let i = 0; i < numRows; i++) {
-    rows[i] = boardState.columns.map((col) => col.notes[i]?.title || "");
+    rows[i] = boardState.columns.map((col) => getMdLink(col.notes[i]));
   }
 
   const body = rows.map((r) => "| " + r.join(" | ") + " |").join("\n") + "\n";
   const timestamp = `_Last updated at ${new Date().toLocaleString()} by Kanban plugin_`;
 
   return header + headerSep + body + timestamp;
+}
+
+export function getMdLink(note: NoteData): string {
+  if ((note?.title !== undefined) && (note?.id !== undefined)) {
+    return "[" + note.title + "](:/" + note.id + ")";
+  } else return "";
 }
 
 export async function getBoardState(board?: Board): Promise<BoardState> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import createBoard, {
   getBoardState,
   parseConfigNote,
   getMdTable,
+  getMdList
 } from "./board";
 import {
   getConfigNote,
@@ -201,8 +202,14 @@ async function showBoard() {
         );
       }
 
-      if (msg.type !== "poll")
-        setAfterConfig(openBoard.configNoteId, getMdTable(newState));
+
+      if (msg.type !== "poll"){
+        if ((openBoard.isValid) && (openBoard.parsedConfig.display?.markdown == "list"))
+          setAfterConfig(openBoard.configNoteId, getMdList(newState));
+        else
+          setAfterConfig(openBoard.configNoteId, getMdTable(newState));
+      }
+
 
       log(
         `Sending back update to webview: \n${JSON.stringify(

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,9 @@ async function showBoard() {
       if (msg.type !== "poll"){
         if ((openBoard.isValid) && (openBoard.parsedConfig.display?.markdown == "list"))
           setAfterConfig(openBoard.configNoteId, getMdList(newState));
-        else
+        else if ((openBoard.isValid) &&
+                 (openBoard.parsedConfig.display?.markdown == "table" ||
+                  openBoard.parsedConfig.display?.markdown == undefined))
           setAfterConfig(openBoard.configNoteId, getMdTable(newState));
       }
 


### PR DESCRIPTION
This PR adds two features to the Markdown view of the Kanban:
1. Note links.
2. Optional list view as suggested in [issue #17](https://github.com/joplin/plugin-kanban/issues/17).

The default view is still the table view. In order to switch to list view a new `display` key was added to the Kanban config YAML. By setting `markdown: list` under `display`, one can switch to list view.

I believe this makes Kanban more convenient to use on mobile.

Preview of note links in list view:
<img width="743" alt="image" src="https://user-images.githubusercontent.com/17462125/155223522-9e441f9e-fe67-4189-b5c0-91a4d6d0ceea.png">

Preview of note links in table view:
<img width="925" alt="image" src="https://user-images.githubusercontent.com/17462125/154737290-e48f78f0-add5-4f5f-a821-1912f8499d2c.png">
