### PR TITLE
Excluded tag filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,19 @@ columns:
 ...
 ```
 
-Filters can contain the same rules as columns, except for the `rootNotebookPath` property. This defines the notebook from which notes are displayed on the board. By default, it is the parent notebook of the config note, but you can set it to anything. It's a `/` separated path so with a notebook structure like
+Filters can contain the same rules as columns, and more. Here's the list of supported rules apart from [columns](#columns) rules:
 
-```
-Parent/
-├─ Nested Parent/
-│  ├─ Kanban board/
-```
+* `rootNotebookPath: ...` This defines the notebook from which notes are displayed on the board. By default, it is the parent notebook of the config note, but you can set it to anything. It's a `/` separated path so with a notebook structure like
 
-To give the path to `Kanban board` you should write `"Parent/Nested Parent/Kanban board"`
+  ```
+  Parent/
+  ├─ Nested Parent/
+  │  ├─ Kanban board/
+  ```
+
+  To give the path to `Kanban board` you should write `"Parent/Nested Parent/Kanban board"`
+
+* `-tag: ...` Exclude note if the note has the given tag. You can also use `-tags` to define a list tags.
 
 To edit the filters via the config dialog, click the gear icon next to the board name.
 

--- a/src/board.ts
+++ b/src/board.ts
@@ -1,6 +1,6 @@
 import { getNotebookPath, getNoteById } from "./noteData";
 
-import rules from "./rules";
+import { rules, filtersRules } from "./rules";
 import { parseConfigNote } from "./parser";
 import { Action } from "./actions";
 import {
@@ -135,8 +135,8 @@ export default class Board {
     for (const key in configObj.filters) {
       let val = configObj.filters[key];
       if (typeof val === "boolean") val = `${val}`;
-      if (val && key in rules) {
-        const rule = await rules[key](val, rootNotebookPath, configObj);
+      if (val && key in filtersRules) {
+        const rule = await filtersRules[key](val, rootNotebookPath, configObj);
         this.baseFilters.push(rule);
         if (key === "tag") this.hiddenTags.push(val as string);
         else if (key === "tags")

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,5 @@
 import * as yaml from "js-yaml";
-import rules from "./rules";
+import { rules, filtersRules } from "./rules";
 import { Config, Message } from "./types";
 
 const configRegex = /([\s\S]*?)```kanban([\s\S]*?)```([\s\S]*)/;
@@ -56,7 +56,7 @@ export const validateConfig = (config: Config | {} | null): Message | null => {
     if (typeof config.filters !== "object" || Array.isArray(config.filters))
       return configErr("Filters has to contain a dictionary of rules");
     for (const key in config.filters) {
-      if (!(key in rules) && key !== "rootNotebookPath")
+      if (!(key in filtersRules) && key !== "rootNotebookPath")
         return configErr(`Invalid rule type "${key}" in filters`);
     }
   }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -139,7 +139,7 @@ export const rules: Record<string, RuleFactory> = {
   },
 };
 
-const _filtersRules : Record<string, RuleFactory> = {
+const _filtersRules: Record<string, RuleFactory> = {
   "-tag": async (arg: string | string[]) => {
     const tagName = Array.isArray(arg) ? arg[0] : arg;
 
@@ -164,7 +164,7 @@ const _filtersRules : Record<string, RuleFactory> = {
     };
   },
 }
-export const filtersRules: Record<string, RuleFactory> = Object.assign({},rules,_filtersRules);
+export const filtersRules: Record<string, RuleFactory> = Object.assign({}, rules, _filtersRules);
 
 const editorTypes = {
   filters: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,2 +1,5 @@
 export const capitalize = (s: string) =>
-  s.replace(/^\w/, (c) => c.toUpperCase());
+  s.replace(/^-?\w/, (c) => c.toUpperCase());
+
+export const toggleSingularPlural = (s: string) =>
+  s.endsWith("s") ? s.slice(0, -1) : s + "s";


### PR DESCRIPTION
My attempt to add [Excluded tag filters](https://github.com/joplin/plugin-kanban/issues/29).

**Example:**
```kanban
filters:
  tag: tasks
  -tag: archived
columns:
  - name: Backlog
    backlog: true
  - name: Ongoing
    tags:
      - wip
  - name: Done
    completed: true
```

will add test case later