### PR TITLE
Optionally show notebook tag and title on each card

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -217,6 +217,7 @@ export default class Board {
       name: this.boardName,
       messages: [],
       hiddenTags: [],
+      displayConfig: this.parsedConfig?.display ?? {},
     };
 
     if (this.isValid) {

--- a/src/gui/Card.tsx
+++ b/src/gui/Card.tsx
@@ -1,16 +1,20 @@
-import React from "react";
+import React, { useContext } from "react";
 import styled from "styled-components";
-import { IoMdPricetag } from "react-icons/io";
+import { IoMdFolder, IoMdPricetag } from "react-icons/io";
 import { IoCalendarOutline } from "react-icons/io5";
 import moment from "moment";
 
 import type { NoteData } from "../types";
+import { BoardContext } from "./index";
 
 const dateFmt = document.getElementById('date-fmt')?.innerHTML || ""
 
 export default React.forwardRef<HTMLDivElement, { note: NoteData }>(
   ({ note }, ref) => {
-    const { title, tags, due } = note;
+    
+    const board = useContext(BoardContext);
+    
+    const { title, tags, due, notebookData: notebook } = note;
 
     const renderExtra = (
       key: number,
@@ -23,10 +27,28 @@ export default React.forwardRef<HTMLDivElement, { note: NoteData }>(
         {text}
       </ExtraItem>
     );
+
     const extras: [React.ReactNode, string, string?][] = tags.map((tag) => [
       <IoMdPricetag size="1rem" />,
       tag,
     ]);
+
+    if (board.displayConfig.showNotebookTag) {
+      const { icon } = notebook;
+      extras.unshift([
+        icon ? (
+          icon.dataUrl ? (
+            <DataIcon alt={notebook.title} src={icon.dataUrl} />
+          ) : (
+            <span>{icon.emoji}</span>
+          )
+        ) : (
+          <IoMdFolder size="1rem" />
+        ),
+        notebook.title,
+      ]);
+    }
+
     if (due > 0) {
       const dueDate = new Date(due);
       const dateStr = moment(dueDate).format(dateFmt);
@@ -82,4 +104,9 @@ const ExtraItem = styled.div<{ color: string }>(({ color }) => ({
 
 const IconCont = styled.span({
   marginRight: "4px",
+});
+
+const DataIcon = styled.img({
+  maxHeight: "1rem",
+  maxWidth: "1rem",
 });

--- a/src/gui/index.tsx
+++ b/src/gui/index.tsx
@@ -1,16 +1,17 @@
 import React from "react";
 import { render } from "react-dom";
 import styled from "styled-components";
-import { IoMdSettings, IoMdAdd } from "react-icons/io";
+import { IoMdSettings, IoMdAdd, IoMdEye } from "react-icons/io";
 
 import { capitalize } from "../utils";
 import { DispatchFn, useRemoteBoard } from "./hooks";
 import { DragDropContext } from "./DragDrop";
 import Column from "./Column";
-import type { Message } from "../types";
+import type { BoardState, Message } from "../types";
 
 export const DispatchContext = React.createContext<DispatchFn>(async () => {});
 export const IsWaitingContext = React.createContext<boolean>(false);
+export const BoardContext = React.createContext<BoardState>({} as BoardState);
 
 function MessageBox({
   message,
@@ -57,49 +58,59 @@ function App() {
   }));
 
   const cont = board ? (
-    <Container>
-      <Header>
-        {board.name}
-        <IconCont
-          onClick={() =>
-            dispatch({ type: "settings", payload: { target: "filters" } })
-          }
-        >
-          <IoMdSettings size="25px" />
-        </IconCont>
-
-        <IconCont
-          onClick={() =>
-            dispatch({ type: "settings", payload: { target: "columnnew" } })
-          }
-        >
-          <IoMdAdd size="25px" />
-        </IconCont>
-      </Header>
-
-      <MessagesCont>
-        {board.messages.map((msg, idx) => (
-          <MessageBox
-            key={idx}
-            message={msg}
-            onMsgAction={(action) =>
-              dispatch({
-                type: "messageAction",
-                payload: { actionName: action, messageId: msg.id },
-              })
+    <BoardContext.Provider value={board}>
+      <Container>
+        <Header>
+          {board.name}
+          <IconCont
+            onClick={() =>
+              dispatch({ type: "settings", payload: { target: "filters" } })
             }
-          />
-        ))}
-      </MessagesCont>
+          >
+            <IoMdSettings size="25px" />
+          </IconCont>
 
-      {board.columns && (
-        <ColumnsCont>
-          {notesToShow?.map(({ name, notes }) => (
-            <Column key={name} name={name} notes={notes} />
+          <IconCont
+            onClick={() =>
+              dispatch({ type: "settings", payload: { target: "display" } })
+            }
+          >
+            <IoMdEye size="25px" />
+          </IconCont>
+
+          <IconCont
+            onClick={() =>
+              dispatch({ type: "settings", payload: { target: "columnnew" } })
+            }
+          >
+            <IoMdAdd size="25px" />
+          </IconCont>
+        </Header>
+
+        <MessagesCont>
+          {board.messages.map((msg, idx) => (
+            <MessageBox
+              key={idx}
+              message={msg}
+              onMsgAction={(action) =>
+                dispatch({
+                  type: "messageAction",
+                  payload: { actionName: action, messageId: msg.id },
+                })
+              }
+            />
           ))}
-        </ColumnsCont>
-      )}
-    </Container>
+        </MessagesCont>
+
+        {board.columns && (
+          <ColumnsCont>
+            {notesToShow?.map(({ name, notes }) => (
+              <Column key={name} name={name} notes={notes} />
+            ))}
+          </ColumnsCont>
+        )}
+      </Container>
+    </BoardContext.Provider>
   ) : (
     <h1>Loading...</h1>
   );

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -151,10 +151,14 @@ const editorTypes = {
     completed: "checkbox",
     backlog: "checkbox",
   },
+  display: {
+    showNotebookTag: "checkbox",
+  },
 };
 
 export const getRuleEditorTypes = (targetPath: string) => {
   if (targetPath === "filters") return editorTypes.filters;
+  if (targetPath === "display") return editorTypes.display;
   if (targetPath.startsWith("column")) return editorTypes.columns;
   throw new Error(`Unkown target path ${targetPath}`);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,8 @@ export interface Config {
     backlog?: boolean;
   }[];
   display: {
-    markdown: string;
+    markdown?: string;
+    showNotebookTag?: boolean;
   };
 }
 
@@ -79,6 +80,7 @@ export interface BoardState {
   }[];
   hiddenTags: string[];
   messages: Message[];
+  displayConfig: Config["display"];
 }
 
 // Joplin API related types
@@ -96,11 +98,22 @@ export interface ConfigNote {
   body: string;
 }
 
+export interface Folder {
+  id: string;
+  title: string;
+  parent_id: string;
+  icon: null | {
+    emoji: string;
+    dataUrl?: string;
+  };
+}
+
 export interface NoteData {
   id: string;
   title: string;
   tags: string[];
   notebookId: string;
+  notebookData: Folder;
   isTodo: boolean;
   isCompleted: boolean;
   due: number;

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -66,6 +66,12 @@ const note = (args: Partial<NoteData> = {}): NoteData => ({
   id: "id",
   title: "title",
   notebookId: parentNb,
+  notebookData: {
+    id: parentNb,
+    title: "notebook",
+    icon: { emoji: "☢️" },
+    parent_id: ""
+  },
   tags: ["task"],
   createdTime: mockTime,
   due: 0,
@@ -90,6 +96,7 @@ const state = (
     { name: "Working", notes: working },
     { name: "Done", notes: done },
   ],
+  displayConfig: {},
 });
 
 describe("Board", () => {


### PR DESCRIPTION
Pretty useful to arrange cards across all projects at once.

Not sure if I had to make a separate context and config dialog or if there was a simpler way :)

![image](https://user-images.githubusercontent.com/336598/210645520-2c782504-a19e-488d-ac28-3397c1ae204a.png)

The API docs say "icon" is "text" while it seems to be either a `""` or a JSON object, not sure if it can be something else so I put in a try-catch just in case.