### PR TITLE
basic implementation for exclude filter

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -189,7 +189,7 @@ export default class Board {
     );
     if (matchesBaseFilters) {
       const foundCol = this.nonBacklogColumns.find(({ rules }) =>
-        rules.some(({ filterNote }) => filterNote(note))
+        rules.every(({ filterNote }) => filterNote(note))
       );
       if (foundCol) return foundCol.name;
       if (this.backlogColumn) return this.backlogColumn.name;

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -81,6 +81,21 @@ const rules: Record<string, RuleFactory> = {
     };
   },
 
+  async alltags(tagNames: string | string[], rootNbPath: string, config: Config) {
+    if (!Array.isArray(tagNames)) tagNames = [tagNames];
+    const tagRules = await Promise.all(
+      tagNames.map((t) => rules.tag(t, rootNbPath, config))
+    );
+    return {
+      name: "alltags",
+      filterNote: (note: NoteData) =>
+        tagRules.every(({ filterNote }) => filterNote(note)),
+      set: (noteId: string) => tagRules.flatMap(({ set }) => set(noteId)),
+      unset: (noteId: string) => tagRules.flatMap(({ unset }) => unset(noteId)),
+      editorType: "text",
+    };
+  },
+
   async notebookPath(path: string | string[], rootNotebookPath: string) {
     if (Array.isArray(path)) path = path[0];
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -18,26 +18,52 @@ type RuleFactory = (
  */
 const rules: Record<string, RuleFactory> = {
   async tag(arg: string | string[]) {
-    const tagName = Array.isArray(arg) ? arg[0] : arg;
-    const tagID = (await getTagId(tagName)) || (await createTag(tagName));
-    return {
-      name: "tag",
-      filterNote: (note: NoteData) => note.tags.includes(tagName),
-      set: (noteId: string) => [
-        {
-          type: "post",
-          path: ["tags", tagID, "notes"],
-          body: { id: noteId },
-        },
-      ],
-      unset: (noteId: string) => [
-        {
-          type: "delete",
-          path: ["tags", tagID, "notes", noteId],
-        },
-      ],
-      editorType: "text",
-    };
+    const tagArg = Array.isArray(arg) ? arg[0] : arg;
+    if (tagArg.startsWith('-')) {
+      const tagName = tagArg.substring(1)
+      console.info('replace ', tagArg, ' with ', tagName)
+      const tagID = (await getTagId(tagName)) || (await createTag(tagName));
+      return {
+        name: "tag",
+        filterNote: (note: NoteData) => !note.tags.includes(tagName),
+        set: (noteId: string) => [
+          {
+            type: "delete",
+            path: ["tags", tagID, "notes", noteId],
+          },
+        ],
+        unset: (noteId: string) => [
+          {
+            type: "post",
+            path: ["tags", tagID, "notes"],
+            body: { id: noteId },
+          },
+        ],
+        editorType: "text",
+      };
+    }
+    else {
+      const tagName = tagArg
+      const tagID = (await getTagId(tagName)) || (await createTag(tagName));
+      return {
+        name: "tag",
+        filterNote: (note: NoteData) => note.tags.includes(tagName),
+        set: (noteId: string) => [
+          {
+            type: "post",
+            path: ["tags", tagID, "notes"],
+            body: { id: noteId },
+          },
+        ],
+        unset: (noteId: string) => [
+          {
+            type: "delete",
+            path: ["tags", tagID, "notes", noteId],
+          },
+        ],
+        editorType: "text",
+      };
+    }
   },
 
   async tags(tagNames: string | string[], rootNbPath: string, config: Config) {

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -237,11 +237,11 @@ describe("Board", () => {
           parent_id: parentNb,
         })) as Board;
 
-        const col1 = board.sortNoteIntoColumn(note({ tags: ["task", "done"] }));
+        const col1 = board.sortNoteIntoColumn(note({ tags: ["task", "done"], isTodo: true, isCompleted: true }));
         expect(col1).toBe("Done");
 
         const col2 = board.sortNoteIntoColumn(
-          note({ tags: ["task", "completed"] })
+          note({ tags: ["task", "completed"], isTodo: true, isCompleted: true })
         );
         expect(col2).toBe("Done");
       });
@@ -276,6 +276,7 @@ describe("Board", () => {
 
         const col1 = board.sortNoteIntoColumn(
           note({
+            tags: ["task", "completed"],
             isCompleted: true,
             isTodo: true,
           })


### PR DESCRIPTION
### Exclude filter

Implementation of exclude filter, which allows me to easily use "work in progress" column for todo with the following configuration : 
```kanban
columns:
  - name: Backlog
    completed: false
    tag: -wip
  - name: Work in progress
    completed: false
    tag: wip
  - name: Finished
    completed: true
    tag: -wip
```

May be a solution to #29

### All Tags

Also added an "alltags" rule to ensure that all tags are present or not present, which allows for example to add a "Priority" column with the following configuration
```kanban
columns:
  - name: Backlog
    completed: false
    alltags:
      - -prio
      - -wip
  - name: Priorities
    completed: false
    alltags:
      - prio
      - -wip
  - name: Work in progress
    completed: false
    alltags:
      - -prio
      - wip
  - name: Done
    completed: true
    alltags:
      - -prio
      - -wip
```

### New Behavior

Change the behaviour of "completed: false" and "completed: true" statement when used with tag/tags statements.
And may have other impacts, like for example the facts that column tag/tags and filters tag/tags must all be satisfied.
See the test modification for the behaviour change

### Next
I can try to write more tests if needed