### PR TITLE
Add "Close" button to close kanban and disable auto closing

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -57,6 +57,10 @@ export interface NewNoteAction {
   };
 }
 
+export interface CloseAction {
+  type: "close";
+}
+
 export type Action =
   | MoveNoteAction
   | LoadAction
@@ -66,4 +70,5 @@ export type Action =
   | OpenNoteAction
   | AddColumnAction
   | DeleteColAction
-  | NewNoteAction;
+  | NewNoteAction
+  | CloseAction;

--- a/src/gui/index.tsx
+++ b/src/gui/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "react-dom";
 import styled from "styled-components";
-import { IoMdSettings, IoMdAdd } from "react-icons/io";
+import { IoMdSettings, IoMdAdd, IoMdClose } from "react-icons/io";
 
 import { capitalize } from "../utils";
 import { DispatchFn, useRemoteBoard } from "./hooks";
@@ -59,6 +59,13 @@ function App() {
   const cont = board ? (
     <Container>
       <Header>
+        <IconCont
+          onClick={() => {
+            dispatch({ type: "close" })
+          }}
+        >
+            <IoMdClose size="20px"/>
+        </IconCont>
         {board.name}
         <IconCont
           onClick={() =>
@@ -147,7 +154,7 @@ const IconCont = styled("div")({
   alignItems: "center",
   borderRadius: "5px",
 
-  "&:first-child": {
+  "&:nth-child(2)": {
     marginLeft: "auto",
   },
   "&:hover": {


### PR DESCRIPTION
Implements #21 

- Added a "close" button at the left of the kanban title  to close kanban
- Disabled auto closing if user open a note which is not in the current kanban  (as user could close the kanban by using the close button)

![Screenshot 2023-06-22 at 10 04 30 AM](https://github.com/joplin/plugin-kanban/assets/82716/b0ea4086-c190-43c8-806e-bde19852aba9)
