### PR TITLE
Fixed sort orders based on note properties available in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ display:
 
 Visual examples and more info: https://github.com/joplin/plugin-kanban/pull/19
 
+### Sort
+
+By default, the kanban plugin sorts each column based on the user's dragging and dropping of notes across the kanban board, with new notes going at the top. To specify a fixed sort pattern based on note properties instead, use the following config:
+
+```yaml
+```kanban
+sort:
+  by: title
+```
+
+Descending sort order may be specified by prefixing `-`, e.g., `-title`.
+
+The configured sort order will apply to all columns.
+
 ## Further information
 
 If you want to know more about the workings of the plugin or its development check out the [original proposal](https://discourse.joplinapp.org/t/kanban-board-project/17469) and the [progress reports](https://discourse.joplinapp.org/t/kanban-board-project/17469)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -61,6 +61,15 @@ export const validateConfig = (config: Config | {} | null): Message | null => {
     }
   }
 
+  if ("sort" in config) {
+    if (typeof config.sort !== "object" || config.sort.by === undefined)
+      return configErr("Sort must be a dictionary with a single 'by' field");
+    let cs = config.sort.by;
+    if (cs.startsWith('-')) cs = cs.substring(1);
+    if (['createdTime', 'title'].indexOf(cs) === -1)
+      return configErr("Sort must be one of 'createdTime', 'title'; optionally prefix by '-' for descending order");
+  }
+
   for (const col of config.columns) {
     if (typeof col !== "object" || Array.isArray(col))
       return configErr(

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,9 @@ export interface Config {
     [ruleName: string]: RuleValue;
     rootNotebookPath?: string;
   };
+  sort: {
+    by?: string;
+  };
   columns: {
     [ruleName: string]: RuleValue;
     name: string;


### PR DESCRIPTION
Solves #46 -- pretty useful for multiple views / prioritization of notes. E.g., I prefix all of my note titles with either a date or a priority number, and then use descending sort order.